### PR TITLE
Replace site with redirect to developer.rubrik.com

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,4 +1,4 @@
-name: Deploy API Documentation
+name: Deploy Redirect to GitHub Pages
 
 on:
   push:
@@ -11,53 +11,20 @@ permissions:
   id-token: write
 
 jobs:
-  # JOB 1: The Build (Runs on your high-RAM Internal Runner)
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Check Disk Space
-        run: |
-            echo "--- Disk Usage ---"
-            df -h
-            echo "--- Largest Folders ---"
-            sudo du -h -d 1 / | sort -hr | head -n 10
-
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          # This frees up about 20GB by removing heavy tools
-          tool-cache: true
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: true
-          swap-storage: true  
-
-      - name: Check Disk Space AGAIN
-        run: |
-            echo "--- Disk Usage ---"
-            df -h
-            echo "--- Largest Folders ---"
-            sudo du -h -d 1 / | sort -hr | head -n 10
-
-      - name: Upload Pages Artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          # Path to the folder containing your index.html
-          path: '.' 
-
-  # JOB 2: The Deployment (Runs on GitHub-hosted, uses zero RAM)
   deploy:
-    needs: build
     runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Upload Pages Artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'redirect-site'
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/redirect-site/404.html
+++ b/redirect-site/404.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Rubrik API Documentation — Redirecting</title>
+  <meta http-equiv="refresh" content="0; url=https://developer.rubrik.com">
+  <link rel="canonical" href="https://developer.rubrik.com">
+  <style>
+    body { font-family: sans-serif; text-align: center; padding: 4rem; color: #333; }
+    a { color: #0066cc; }
+  </style>
+</head>
+<body>
+  <h1>Rubrik API Documentation Has Moved</h1>
+  <p>This site has moved to <a href="https://developer.rubrik.com">developer.rubrik.com</a>.</p>
+  <p>If you are not redirected automatically, <a href="https://developer.rubrik.com">click here</a>.</p>
+  <script>window.location.replace("https://developer.rubrik.com");</script>
+</body>
+</html>

--- a/redirect-site/README.md
+++ b/redirect-site/README.md
@@ -1,0 +1,8 @@
+# Redirect Site
+
+This directory contains the deployed GitHub Pages content for the `rubrik-api-documentation` repository.
+
+All URLs redirect to [developer.rubrik.com](https://developer.rubrik.com).
+
+- `index.html` — handles requests to the root
+- `404.html` — handles all other paths (GitHub Pages serves this for any unmatched route)

--- a/redirect-site/index.html
+++ b/redirect-site/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Rubrik API Documentation — Redirecting</title>
+  <meta http-equiv="refresh" content="0; url=https://developer.rubrik.com">
+  <link rel="canonical" href="https://developer.rubrik.com">
+  <style>
+    body { font-family: sans-serif; text-align: center; padding: 4rem; color: #333; }
+    a { color: #0066cc; }
+  </style>
+</head>
+<body>
+  <h1>Rubrik API Documentation Has Moved</h1>
+  <p>This site has moved to <a href="https://developer.rubrik.com">developer.rubrik.com</a>.</p>
+  <p>If you are not redirected automatically, <a href="https://developer.rubrik.com">click here</a>.</p>
+  <script>window.location.replace("https://developer.rubrik.com");</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Adds `redirect-site/index.html` and `redirect-site/404.html` — both redirect to https://developer.rubrik.com
- Updates the GitHub Pages workflow to deploy only `redirect-site/` instead of the full repo root
- Simplifies the workflow (removes unnecessary disk-space cleanup steps)

The `404.html` is the key to site-wide coverage: GitHub Pages serves it for any URL path that doesn't exist, so every old link redirects automatically.

## Why not a real 301?

GitHub Pages serves static files only — there's no way to set HTTP status codes or response headers, so a true `301 Moved Permanently` is not possible on `rubrikinc.github.io`. Meta-refresh (what this PR uses) is the standard workaround. Google explicitly treats single-target meta-refresh as equivalent to a 301 for ranking transfer, so SEO impact is negligible.

A real 301 would require moving hosting (Cloudflare Pages / Netlify / Vercel with a `_redirects` file), which isn't worth the effort for this site.

## Why not `jekyll-redirect-from`?

The [`jekyll-redirect-from`](https://github.com/jekyll/jekyll-redirect-from) plugin is whitelisted on GitHub Pages and would let us set `redirect_to:` front matter on each old page for per-path mapping (e.g. `/rest-apis/v1/clusters` → a specific new page on developer.rubrik.com). However:

- It also generates meta-refresh HTML — not real 301s. Same mechanism as this PR, no SEO advantage.
- Its only benefit is **per-page mapping**, which would require maintaining a list of old-path → new-path mappings.
- We don't have a meaningful number of inbound links to specific deep paths that would justify that maintenance burden. Most traffic is people hitting the root or following stale bookmarks.

The catch-all `404.html` approach in this PR is simpler and functionally equivalent for our use case.

## Test plan

- [ ] After merge, verify https://rubrikinc.github.io/rubrik-api-documentation/ redirects to developer.rubrik.com
- [ ] Verify a deep path (e.g. `/rest-apis/`) also redirects